### PR TITLE
Send Permissions Updated on Org Creation

### DIFF
--- a/application/main/events.py
+++ b/application/main/events.py
@@ -48,11 +48,12 @@ def on_join_org(org_name):
 
 @socketio.on("disconnect")
 def on_disconnect():
-    print("Client disconnected")
     room = request.sid
     username = client_service.get_username_by_room(room)
-    client_service.remove_client_by_room(room)
-    user = user_service.get_user(username)
-    for org in user.orgs:
-        event_service.send_org_member_offline(org.name, username)
+    if username: 
+        print("Client disconnected:", username)
+        client_service.remove_client_by_room(room)
+        user = user_service.get_user(username)
+        for org in user.orgs:
+            event_service.send_org_member_offline(org.name, username)
 

--- a/application/main/routes/channel.py
+++ b/application/main/routes/channel.py
@@ -64,7 +64,7 @@ def channels():
                 # notify that permissions were updated for these users and that they've been added to a new channel
                 usernames = map(lambda user: user.username, users) 
                 for username in usernames:
-                    socket_service.send_user(username, "permissions-updated")
+                    event_service.send_permissions_updated(username)
                     event_service.send_added_to_channel(username, channel)
                 response = {"successful": True, }
                 return jsonify(response)

--- a/application/main/routes/org.py
+++ b/application/main/routes/org.py
@@ -90,8 +90,8 @@ def org_invite_response():
         socket_service.send_user(user.username, "added-to-org", org.name)
         for channel in public_channels:
             event_service.send_added_to_channel(user.username, channel)
-        # inform user that their permissions have been updated
-        socket_service.send_user(user.username, "permissions-updated")
+        # inform user that their permissions have been updated        
+        event_service.send_permissions_updated(user.username)
     else:
         db.session.commit()
     response = {"successful": True}
@@ -183,7 +183,8 @@ def orgs():
                 db.session.commit()
                 
                 org_service.notify_invitees(invited_email_addresses, org_name, inviter.username)
-                socket_service.send_user(current_user.username, "added-to-org", org_name)
+                event_service.send_permissions_updated(inviter.username)
+                event_service.send_added_to_org(inviter.username, org_name)
                 event_service.send_added_to_channel(inviter.username, default_channel)
                 response["successful"] = True
                 return response

--- a/application/main/routes/permission.py
+++ b/application/main/routes/permission.py
@@ -8,21 +8,17 @@ from ...models.OrgMemberPermission import OrgMemberPermission, org_member_permis
 from ...models.ChannelMemberPermission import ChannelMemberPermission, channel_member_permission_schema
 from ..services import permission_service
 
-@main.route("/permission/", methods=["GET"])
+@main.route("/permission", methods=["POST"])
 # @login_required
 def get_permissions():
     """
-    [GET] - grabs a user's OrgMemberPermissions and ChannelMemberPermissions from the DB. The returned JSON object contains two maps. org_member_perms organizes OrgMemberPermissions by key org_name (value is a list of OrgMemberPermission for that org). channel_member_perms organizes ChannelMemberPermissions by key org_name (value is another map where key is channel_name and value is a list of ChannelMemberPermission)
-    Path: /permission/?username={username}
+    [POST] - grabs a user's OrgMemberPermissions and ChannelMemberPermissions from the DB. The returned JSON object contains two maps. org_member_perms organizes OrgMemberPermissions by key org_name (value is a list of OrgMemberPermission for that org). channel_member_perms organizes ChannelMemberPermissions by key org_name (value is another map where key is channel_name and value is a list of ChannelMemberPermission)
     Response Body: {org_member_perms, channel_member_perms}
     """
-    # username = current_user.username
-    username = request.args.get("username")
-    org_member_perms = db.session.query(OrgMemberPermission).filter_by(username=username).all()
-    channel_member_perms = db.session.query(ChannelMemberPermission).filter_by(username=username).all()
+    username = current_user.username
     response = {}
-    response["org_member_perms"] = permission_service.gen_org_member_perms_map(org_member_perms)
-    response["channel_member_perms"] = permission_service.gen_channel_member_perms_map(channel_member_perms)
+    response["org_member_perms"] = permission_service.get_org_member_perms(username)
+    response["channel_member_perms"] = permission_service.get_channel_member_perms(username)
     return jsonify(response)
 
 # EXAMPLES

--- a/application/main/services/client_service.py
+++ b/application/main/services/client_service.py
@@ -12,7 +12,6 @@ def add_client(username, room):
 def remove_client_by_room(room):
     for username, client in list(clients.items()):
         if client.room == room:
-            print(f"Removed {username} from clients")
             del clients[username]
             break
 

--- a/application/main/services/event_service.py
+++ b/application/main/services/event_service.py
@@ -9,6 +9,9 @@ def send_new_org_member(org_name, username):
     info = {"org_name": org_name, "org_member": org_member_client.__dict__}
     socket_service.send_org(org_name, "new-org-member", info) 
 
+def send_added_to_org(username, org_name):
+    socket_service.send_user(username, "added-to-org", org_name)
+
 # ORG MEMBER ONLINE STATUS 
 def send_org_member_online(org_name, username):
     info = {"org_name": org_name, "username": username}
@@ -38,3 +41,7 @@ def send_private_message_received(message):
     receiver_username, sender_username = message["receiver"], message["sender"]
     socket_service.send_user(receiver_username, "message-received", message)
     socket_service.send_user(sender_username, "message-received", message)
+
+# PERMISSIONS
+def send_permissions_updated(username):
+    socket_service.send_user(username, "permissions-updated")

--- a/application/main/services/permission_service.py
+++ b/application/main/services/permission_service.py
@@ -1,8 +1,22 @@
 import collections
-from ...models.OrgMemberPermission import org_member_permission_schema
-from ...models.ChannelMemberPermission import channel_member_permission_schema
+from ...models.OrgMemberPermission import OrgMemberPermission, org_member_permission_schema
+from ...models.ChannelMemberPermission import ChannelMemberPermission, channel_member_permission_schema
 from . import client_service, socket_service
+from ... import db
 
+def get_org_member_perms(username):
+    """
+    Queries for a user's org member permissions and returns a permissions map with org_name as the key
+    """
+    org_member_perms = db.session.query(OrgMemberPermission).filter_by(username=username).all()
+    return gen_org_member_perms_map(org_member_perms)
+
+def get_channel_member_perms(username):
+    """
+    Queries for a user's org member permissions and returns a permissions map with org_name as the top level key and channel name as the second level key 
+    """
+    channel_member_perms = db.session.query(ChannelMemberPermission).filter_by(username=username).all()
+    return gen_channel_member_perms_map(channel_member_perms)
 
 def gen_org_member_perms_map(org_member_perms):
     """


### PR DESCRIPTION
- Updated disconnect logic. I noticed that sometimes the disconnecting socket room was not associated with a user when force quitting the server (leading to username being None). Now we only try to get_user when username is not None, which will prevent sql alchemy error (expected username to exist in db because of .one())
- Created an event_service method for sending "permissions-changed" event, was missing when creating an org (now notifying the org creator that his/her permissions have been updated)
- Created an event_service method for sending "added-to_org" event
- Updated permission route to POST
- Created permission_service methods: get_org_member_perms and get_channel_member_perms to clean up permissions route