### PR TITLE
Fetch previous messages and message date time fixes / improvements

### DIFF
--- a/application/main/routes/message.py
+++ b/application/main/routes/message.py
@@ -13,9 +13,9 @@ from ...models.Channel import Channel
 # @login_required
 def get_channel_messages():
         data = request.json
-        org_name, channel_name = data["org_name"], data["channel_name"]
+        org_name, channel_name, before_date_time = data["org_name"], data["channel_name"], data.get("before_date_time")
         channel = channel_service.get_channel(org_name, channel_name)        
-        messages = message_service.get_channel_messages(channel)
+        messages = message_service.get_channel_messages(channel, before_date_time)
         client_messages = message_service.populate_channel_messages_client(messages)
         response = {}
         response['messages'] = json.dumps(client_messages)
@@ -28,8 +28,8 @@ def get_private_messages():
         data = request.json
         response = {}
         username = current_user.username
-        org_name, partner_username =  data["org_name"], data["partner_username"]
-        messages = message_service.get_private_messages(org_name, username, partner_username)
+        org_name, partner_username, before_date_time =  data["org_name"], data["partner_username"], data.get("before_date_time")
+        messages = message_service.get_private_messages(org_name, username, partner_username, before_date_time)
         client_messages = message_service.populate_private_messages_client(messages)
         response['messages'] = json.dumps(client_messages)
         return response

--- a/application/main/services/datetime_service.py
+++ b/application/main/services/datetime_service.py
@@ -1,0 +1,7 @@
+from datetime import datetime
+
+def dt(dt_str):
+    return datetime.strptime(dt_str, "%Y/%m/%d %H:%M:%S:%f")
+
+def string(dt):
+    return dt.strftime("%Y/%m/%d %H:%M:%S:%f")[:-3]


### PR DESCRIPTION
- outfitted fetch channel messages and fetch private routes for optional request body attribute "before_date_time". If supplied, we will query for 25 most recent messages before the provided datetime
- Created datetime service for converting datetime to string and vice-versa
- Added milliseconds to datetime string (messages coming in on the same second were not sorted properly before this)
- Now properly selecting the last 25 messages (order by descending datetime, then reverse results of query to restore original order)